### PR TITLE
update the typespecs from 'binary' atom to binary() type

### DIFF
--- a/include/enenra.hrl
+++ b/include/enenra.hrl
@@ -6,20 +6,20 @@
 %%
 
 -record(credentials, {
-    type :: binary,
-    project_id :: binary,
-    private_key_id :: binary,
-    private_key :: binary,
-    client_email :: binary,
-    client_id :: binary
+    type :: binary(),
+    project_id :: binary(),
+    private_key_id :: binary(),
+    private_key :: binary(),
+    client_email :: binary(),
+    client_id :: binary()
 }).
 -type credentials() :: #credentials{
-    type :: binary,
-    project_id :: binary,
-    private_key_id :: binary,
-    private_key :: binary,
-    client_email :: binary,
-    client_id :: binary
+    type :: binary(),
+    project_id :: binary(),
+    private_key_id :: binary(),
+    private_key :: binary(),
+    client_email :: binary(),
+    client_id :: binary()
 }.
 -export_type([credentials/0]).
 
@@ -28,51 +28,51 @@
     token_type
 }).
 -type access_token() :: #access_token{
-    access_token :: binary,
-    token_type :: binary
+    access_token :: binary(),
+    token_type :: binary()
 }.
 -export_type([access_token/0]).
 
 -record(bucket, {
-    id :: binary,
-    projectNumber :: binary,
-    name :: binary,
-    timeCreated :: binary,
-    updated :: binary,
-    location :: binary,
-    storageClass :: binary
+    id :: binary(),
+    projectNumber :: binary(),
+    name :: binary(),
+    timeCreated :: binary(),
+    updated :: binary(),
+    location :: binary(),
+    storageClass :: binary()
 }).
 -type bucket() :: #bucket{
-    id :: binary,
-    projectNumber :: binary,
-    name :: binary,
-    timeCreated :: binary,
-    updated :: binary,
-    location :: binary,
-    storageClass :: binary
+    id :: binary(),
+    projectNumber :: binary(),
+    name :: binary(),
+    timeCreated :: binary(),
+    updated :: binary(),
+    location :: binary(),
+    storageClass :: binary()
 }.
 -export_type([bucket/0]).
 
 -record(object, {
-    id :: binary,
-    name :: binary,
-    bucket :: binary,
-    contentType :: binary,
-    timeCreated :: binary,
-    updated :: binary,
-    storageClass :: binary,
+    id :: binary(),
+    name :: binary(),
+    bucket :: binary(),
+    contentType :: binary(),
+    timeCreated :: binary(),
+    updated :: binary(),
+    storageClass :: binary(),
     size :: integer(),
-    md5Hash :: binary
+    md5Hash :: binary()
 }).
 -type object() :: #object{
-    id :: binary,
-    name :: binary,
-    bucket :: binary,
-    contentType :: binary,
-    timeCreated :: binary,
-    updated :: binary,
-    storageClass :: binary,
+    id :: binary(),
+    name :: binary(),
+    bucket :: binary(),
+    contentType :: binary(),
+    timeCreated :: binary(),
+    updated :: binary(),
+    storageClass :: binary(),
     size :: integer(),
-    md5Hash :: binary
+    md5Hash :: binary()
 }.
 -export_type([object/0]).


### PR DESCRIPTION
I was getting dialyzer errors because of the expectation that the fields of the records should be equal to the 'binary' atom.