### PR TITLE
chore: bump jiffy

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,5 +10,5 @@
 
 {deps, [
     {hackney, {git, "https://github.com/benoitc/hackney", {tag, "1.15.2"}}},
-    {jiffy,   {git, "https://github.com/davisp/jiffy",    {tag, "0.15.2"}}}
+    {jiffy,   {git, "https://github.com/davisp/jiffy",    {tag, "1.0.8"}}}
 ]}.


### PR DESCRIPTION
The breaking changes in jiffy 1.0.0 appear to be that calls to `throw/1` has been replaced with calls to `error/1` at a few locations. However, at the few places in enenra where try/catch syntax is used, the catch clause does not match on the error type and hence they should still be catching errors even when `throw/1` has been replaced with calls to `error/1` in jiffy.